### PR TITLE
Auto send link

### DIFF
--- a/app/Console/Commands/ServiceReportAutoSendLink.php
+++ b/app/Console/Commands/ServiceReportAutoSendLink.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Events\UnsignedServiceReportFound;
+use Carbon\Carbon;
+use App\Models\ServiceReport;
+use Illuminate\Console\Command;
+
+class ServiceReportAutoSendLink extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'service-report:send-link';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resend acknowledgement form link email to not signed service report after 48 hours';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $serviceReports = ServiceReport::where('status', ServiceReport::STATUS['sent'])
+            ->whereBetween('email_sent_at', [Carbon::parse('-49 hours'), Carbon::parse('-48 hours')])
+            ->get();
+         
+        foreach ($serviceReports as $serviceReport) {
+            UnsignedServiceReportFound::dispatch($serviceReport);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        Commands\ServiceReportAutoSendLink::class,
     ];
 
     /**
@@ -24,7 +24,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('service-report:send-link')->hourly();
     }
 
     /**

--- a/app/Events/UnsignedServiceReportFound.php
+++ b/app/Events/UnsignedServiceReportFound.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ServiceReport;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class UnsignedServiceReportFound
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * The service report instance.
+     *
+     * @var \App\Models\ServiceReport
+     */
+    public $serviceReport;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(ServiceReport $serviceReport)
+    {
+        $this->serviceReport = $serviceReport;
+    }
+}

--- a/app/Http/Controllers/ServiceFormController.php
+++ b/app/Http/Controllers/ServiceFormController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use App\Models\Customer;
 use Illuminate\Support\Str;
 use App\Models\ServiceReport;
@@ -103,6 +104,9 @@ class ServiceFormController extends Controller
         }
 
         if ($result && ServiceReport::STATUS[$validated['action']] == 2) {
+            $serviceReport->email_sent_at = Carbon::now()->toDateTimeString();
+            $serviceReport->save();
+
             AcknowledgementFormSent::dispatch($serviceReport);
         }
 
@@ -174,6 +178,9 @@ class ServiceFormController extends Controller
         }
 
         if ($result && $validated['status'] == 2) {
+            $serviceReport->email_sent_at = Carbon::now()->toDateTimeString();
+            $serviceReport->save();
+            
             AcknowledgementFormSent::dispatch($serviceReport);
         }
 

--- a/app/Listeners/ResendAcknowledgementFormMail.php
+++ b/app/Listeners/ResendAcknowledgementFormMail.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Mail\ServiceFormSent;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Queue\InteractsWithQueue;
+use App\Events\UnsignedServiceReportFound;
+use App\Traits\ServiceReportEmailLoggerTrait;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ResendAcknowledgementFormMail
+{
+    use ServiceReportEmailLoggerTrait;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  UnsignedServiceReportFound  $event
+     * @return void
+     */
+    public function handle(UnsignedServiceReportFound $event)
+    {
+        $serviceReport = $event->serviceReport;
+        $email = $serviceReport->customer->email;
+        $subject = __('label.service_report.email.resend.plain_subject');
+
+        try {
+            Mail::to($email)
+                ->queue(new ServiceFormSent($serviceReport));
+            
+            $this->writeLog('info', $serviceReport, $subject);
+        } catch(\Exception $e) {
+            $this->writeLog('warning', $serviceReport, $subject, $e->getMessage());
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,13 +2,14 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Registered;
 use App\Events\AcknowledgementFormSent;
 use App\Listeners\SendCustomerCopyMail;
 use App\Events\AcknowledgementFormSigned;
+use App\Events\UnsignedServiceReportFound;
 use App\Listeners\SendAcknowledgementFormMail;
 use App\Listeners\SendCustomerConfirmationMail;
+use App\Listeners\ResendAcknowledgementFormMail;
 use App\Listeners\SendAcknowledgementFormConfirmationMail;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -31,6 +32,9 @@ class EventServiceProvider extends ServiceProvider
         AcknowledgementFormSigned::class => [
             SendCustomerCopyMail::class,
             SendCustomerConfirmationMail::class,
+        ],
+        UnsignedServiceReportFound::class => [
+            ResendAcknowledgementFormMail::class,
         ],
     ];
 

--- a/app/Traits/ServiceReportEmailLoggerTrait.php
+++ b/app/Traits/ServiceReportEmailLoggerTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Log;
+
+trait ServiceReportEmailLoggerTrait 
+{
+    private $emailLabel = 'label.service_report.email.log.general.';
+
+    public function writeLog($type, $model, $subject, $error = null) 
+    {
+        $isSuccess = is_null($error);
+        $parameter = $this->getTransParameter($model, $isSuccess, $subject, $error);
+
+        Log::$type(__($this->getLabelWithStatus($type, $isSuccess), $parameter));
+    }
+
+    private function getTransParameter($model, $isSuccess, $subject, $error = null)
+    {
+        $parameter['subject'] = $subject;
+        $parameter['email'] = $model->customer->email;
+        
+        if (!$isSuccess) {
+            $parameter['error'] = $error;
+        }
+
+        return $parameter;
+    }
+
+    private function getLabelWithStatus($type, $isSuccess)
+    {
+        $status = $isSuccess ? 'success' : 'fail';
+
+        return $this->emailLabel . $status;
+    }
+}

--- a/database/migrations/2021_03_17_102942_add_columns_to_service_reports.php
+++ b/database/migrations/2021_03_17_102942_add_columns_to_service_reports.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnsToServiceReports extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('service_reports', function (Blueprint $table) {
+            $table->after('status', function ($table) {
+                $table->timestamp('email_sent_at')->nullable();
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('service_reports', function (Blueprint $table) {
+            $table->dropColumn('email_sent_at');
+        });
+    }
+}

--- a/resources/lang/en/label.php
+++ b/resources/lang/en/label.php
@@ -471,6 +471,9 @@ return [
                 ],
                 'subject' => 'Acknowledgement Form Email Confirmation | :company',
                 'plain_subject' => 'Acknowledgement Form Email Confirmation'
+            ],
+            'resend' => [
+                'plain_subject' => 'Service Report Acknowledgment Form (Resend)'
             ]
         ],
         'form' => [


### PR DESCRIPTION
**Note:**
- added new column (email_sent_at)
- added trait for service report email logging
- added event and listener for resending unsigned acknowledgement form after 48 hrs
- added an hourly schedule for running a custom artisan command (service-report:send-link)
- might require to run **php artisan event:cache** again for the auto discovery of events